### PR TITLE
Embed GCP credentials in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ BQin requires some credentials.
       access_key_id: {{ must_env "ACCESSS_KEY_ID" }}
       secret_access_key: {{ must_env "SECRET_ACCESS_KEY" }}
     gcp:
-      credential: |
-        {{ must_env "GCP_CREDENTIAL_JSON" }}
+      base64_credential: {{ must_env "GCP_CREDENTIAL_BASE64_JSON" }}
    ```
+   Note: For GCP credentials, specify a Base64-encoded string of the contents of the JSON file
 
 ## Run
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ BQin requires some credentials.
   Reference using GOOGLE_APPLICATION_CREDENTIALS.  
   https://cloud.google.com/docs/authentication/getting-started?hl=en  
 
+ - alternatively, It can be embedded in the config.
+  ```yaml
+  cloud:
+    aws:
+      region: ap-northeast-1
+      access_key_id: {{ must_env "ACCESSS_KEY_ID" }}
+      secret_access_key: {{ must_env "SECRET_ACCESS_KEY" }}
+    gcp:
+      credential: |
+        {{ must_env "GCP_CREDENTIAL_JSON" }}
+   ```
+
 ## Run
 
 ### normally

--- a/cloud/base64_string.go
+++ b/cloud/base64_string.go
@@ -1,0 +1,29 @@
+package cloud
+
+import "encoding/base64"
+
+type Base64String []byte
+
+func (s Base64String) String() string {
+	if s.IsEmpty() {
+		return ""
+	}
+	return base64.StdEncoding.EncodeToString(s)
+}
+
+func (s Base64String) IsEmpty() bool {
+	return s == nil || len(s) == 0
+}
+
+func (s *Base64String) UnmarshalYAML(unmarshal func(interface{}) error) (err error) {
+	var str string
+	if err = unmarshal(&str); err != nil {
+		return
+	}
+	*s, err = base64.StdEncoding.DecodeString(str)
+	return
+}
+
+func (s Base64String) Bytes() []byte {
+	return []byte(s)
+}

--- a/cloud/base64_string_test.go
+++ b/cloud/base64_string_test.go
@@ -1,0 +1,45 @@
+package cloud_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kayac/bqin/cloud"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestBase64String(t *testing.T) {
+	cases := []struct {
+		orig     string
+		isErr    bool
+		expected string
+	}{
+		{
+			orig:  "hoge! DAYO",
+			isErr: true,
+		},
+		{
+			orig:  "eyJ0eXBlIjogImhvZ2Vob2dlIn0=",
+			isErr: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.orig, func(t *testing.T) {
+			decoder := yaml.NewDecoder(strings.NewReader(c.orig))
+			var b64str cloud.Base64String
+			if err := decoder.Decode(&b64str); (err != nil) != c.isErr {
+				t.Errorf("unexpected error: %s", err)
+				return
+			}
+			if c.isErr == true {
+				return
+			}
+			if b64str.String() != c.orig {
+				t.Logf("     got: %s", b64str.String())
+				t.Logf("expected: %s", c.orig)
+				t.Error("unexpected")
+			}
+		})
+	}
+}

--- a/cloud/config.go
+++ b/cloud/config.go
@@ -93,12 +93,16 @@ type GCP struct {
 	WithoutAuthentication bool   `yaml:"without_authentication,omitempty"`
 	BigQueryEndpoint      string `yaml:"big_query_endpoint,omitempty"`
 	CloudStorageEndpoint  string `yaml:"cloud_storage_endpoint,omitempty"`
+	Credential            string `yaml:"credential"`
 }
 
 func (c *GCP) BuildOption(service string) []option.ClientOption {
 	opts := make([]option.ClientOption, 0, 2)
 	if c.WithoutAuthentication {
 		opts = append(opts, option.WithoutAuthentication())
+	}
+	if c.Credential != "" {
+		opts = append(opts, option.WithCredentialsJSON([]byte(c.Credential)))
 	}
 	switch service {
 	case BigQueryServiceID:

--- a/cloud/config.go
+++ b/cloud/config.go
@@ -90,10 +90,10 @@ const (
 )
 
 type GCP struct {
-	WithoutAuthentication bool   `yaml:"without_authentication,omitempty"`
-	BigQueryEndpoint      string `yaml:"big_query_endpoint,omitempty"`
-	CloudStorageEndpoint  string `yaml:"cloud_storage_endpoint,omitempty"`
-	Credential            string `yaml:"credential"`
+	WithoutAuthentication bool         `yaml:"without_authentication,omitempty"`
+	BigQueryEndpoint      string       `yaml:"big_query_endpoint,omitempty"`
+	CloudStorageEndpoint  string       `yaml:"cloud_storage_endpoint,omitempty"`
+	Base64Credential      Base64String `yaml:"base64_credential"`
 }
 
 func (c *GCP) BuildOption(service string) []option.ClientOption {
@@ -101,8 +101,8 @@ func (c *GCP) BuildOption(service string) []option.ClientOption {
 	if c.WithoutAuthentication {
 		opts = append(opts, option.WithoutAuthentication())
 	}
-	if c.Credential != "" {
-		opts = append(opts, option.WithCredentialsJSON([]byte(c.Credential)))
+	if !c.Base64Credential.IsEmpty() {
+		opts = append(opts, option.WithCredentialsJSON(c.Base64Credential.Bytes()))
 	}
 	switch service {
 	case BigQueryServiceID:

--- a/cloud/config_test.go
+++ b/cloud/config_test.go
@@ -46,9 +46,8 @@ credential: |
 	if err != nil {
 		t.Fatalf("unexpected new client error: %s", err)
 	}
-	trans, ok := client.Transport.(*oauth2.Transport)
-	if !ok {
-		t.Fatalf("unexpected client transport type: %#v", client)
+	if trans, ok := client.Transport.(*oauth2.Transport); !ok {
+		t.Fatalf("unexpected client transport type: %#v", trans)
 	}
 }
 

--- a/cloud/config_test.go
+++ b/cloud/config_test.go
@@ -1,0 +1,61 @@
+package cloud_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kayac/bqin/cloud"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/transport"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestGCPCredential(t *testing.T) {
+	yamlStr := fmt.Sprintf(`
+credential: |
+  {
+    "type": "service_account",
+    "project_id": "bqin-test-gcp",
+    "private_key_id": "0000000000000000000000000000000000000000",
+    "private_key": "%s",
+    "client_email": "bqin@bqin-test-gcp.iam.gserviceaccount.com",
+    "client_id": "000000000000000000000",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/bqin%%40bqin-test-gcp.iam.gserviceaccount.com"
+  }
+`, strings.Replace(generatePEM(), "\n", "\\n", -1))
+	gcp := &cloud.GCP{}
+	decoder := yaml.NewDecoder(strings.NewReader(yamlStr))
+	if err := decoder.Decode(gcp); err != nil {
+		t.Fatalf("unexpected decode error: %s", err)
+	}
+	opts := gcp.BuildOption("hoge")
+	if len(opts) != 1 {
+		t.Fatalf("unexpected builded options: %v", opts)
+	}
+	client, _, err := transport.NewHTTPClient(context.Background(), opts...)
+	if err != nil {
+		t.Fatalf("unexpected new client error: %s", err)
+	}
+	trans, ok := client.Transport.(*oauth2.Transport)
+	if !ok {
+		t.Fatalf("unexpected client transport type: %#v", client)
+	}
+}
+
+func generatePEM() string {
+	rsaPrivateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	derRsaPrivateKey := x509.MarshalPKCS1PrivateKey(rsaPrivateKey)
+	buf := new(bytes.Buffer)
+	pem.Encode(buf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: derRsaPrivateKey})
+	return buf.String()
+}

--- a/config_test.go
+++ b/config_test.go
@@ -11,6 +11,7 @@ var ExpectedDefault = []string{}
 
 func TestLoadConfig(t *testing.T) {
 	os.Setenv("AWS_REGION", "ap-northeast-1")
+	os.Setenv("GCP_CREDENTIAL", "HOGEHOGEHOGEHOGE")
 
 	type pattern struct {
 		path                 string
@@ -38,6 +39,13 @@ func TestLoadConfig(t *testing.T) {
 					"s3://bqin.bucket.test/data/(.+)/snapshot_at=([0-9]{8})/.+ => bqin-test-gcp.test.$1_$2",
 				},
 			},
+			{
+				"testdata/config/with_gcp_credntial.yaml",
+				[]string{
+					"s3://bqin.bucket.test/data/user => bqin-test-gcp.test.user",
+					"s3://bqin.bucket.test/data/(.+)/part-([0-9]+).csv => bqin-test-gcp.test.$1_$2",
+				},
+			},
 		}
 		for _, p := range patterns {
 			t.Run(p.path, func(t *testing.T) {
@@ -57,6 +65,7 @@ func TestLoadConfig(t *testing.T) {
 		}
 	})
 
+	os.Unsetenv("GCP_CREDENTIAL")
 	t.Run("fail", func(t *testing.T) {
 		patterns := []pattern{
 			{path: "testdata/config/not_found.yaml"},
@@ -64,14 +73,29 @@ func TestLoadConfig(t *testing.T) {
 			{path: "testdata/config/broken_no_queue_name.yaml"},
 			{path: "testdata/config/broken_no_key_matcher.yaml"},
 			{path: "testdata/config/broken_no_tempbucket_option.yaml"},
+			{path: "testdata/config/with_gcp_credntial.yaml"},
 		}
 		for _, p := range patterns {
 			t.Run(p.path, func(t *testing.T) {
-				_, err := bqin.LoadConfig(p.path)
-				if err == nil {
+				// return error or panic
+				result := errorOrPanic(func() error {
+					_, err := bqin.LoadConfig(p.path)
+					return err
+				})
+				if !result {
 					t.Errorf("LoadConfig(%s) must be failed", p.path)
 				}
 			})
 		}
 	})
+}
+
+func errorOrPanic(target func() error) (result bool) {
+	defer func() {
+		if err := recover(); err != nil {
+			result = true
+		}
+	}()
+	result = target() != nil
+	return
 }

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/kylelemons/godebug v1.1.0
 	github.com/lestrrat-go/backoff v1.0.0
 	github.com/pkg/errors v0.9.1
+	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/api v0.9.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/testdata/config/with_gcp_credntial.yaml
+++ b/testdata/config/with_gcp_credntial.yaml
@@ -1,0 +1,27 @@
+queue_name: s3_to_bq
+
+cloud:
+  gcp:
+    credential: |
+      {{ must_env "GCP_CREDENTIAL" }}
+s3:
+  bucket: bqin.bucket.test
+  region: ap-northeast-1
+
+big_query:
+  project_id: bqin-test-gcp
+  dataset: test
+
+option:
+  temporary_bucket: bqin-import-tmp
+
+rules:
+  - big_query:
+      table: user
+    s3:
+      key_prefix: data/user
+  - big_query:
+      table: $1_$2
+    s3:
+      bucket: bqin.bucket.test
+      key_regexp: data/(.+)/part-([0-9]+).csv

--- a/testdata/config/with_gcp_credntial.yaml
+++ b/testdata/config/with_gcp_credntial.yaml
@@ -2,7 +2,7 @@ queue_name: s3_to_bq
 
 cloud:
   gcp:
-    credential: |
+    base64_credential: |
       {{ must_env "GCP_CREDENTIAL" }}
 s3:
   bucket: bqin.bucket.test


### PR DESCRIPTION
implement:
  ```yaml
  cloud:
    gcp:
      credential: |
        {{ must_env "GCP_CREDENTIAL_BASE64_JSON" }}
   ```

for ecs task with secrets

