### PR TITLE
support gzip parquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ big_query:
 
 option:
   temporary_bucket: my_bucket_name # GCP temporary bucket
+  gzip: true
 
 # define load rule
 rules:
@@ -59,6 +60,8 @@ rules:
     s3:
       bucket: bqin.bucket.test
       key_prefix: data/role
+    option:
+      gzip: false
 ```
 
 A configuration file is parsed by [kayac/go-config](https://github.com/kayac/go-config).
@@ -105,8 +108,12 @@ request file format as
                 "object":"data/user/part-0001.csv"
             },
             "target":{
-               "dataset":"bqin",
-               "table":"user_20200101"
+                "dataset":"bqin",
+                "table":"user_20200101"
+            }
+            "option": {
+                "temporary_bucket":"my_bucket_name",
+                "gzip": true
             }
         }
     ]

--- a/import_option.go
+++ b/import_option.go
@@ -1,0 +1,51 @@
+package bqin
+
+import (
+	"errors"
+
+	"cloud.google.com/go/bigquery"
+)
+
+type ImportOption struct {
+	TemporaryBucket string `yaml:"temporary_bucket" json:"temporary_bucket"`
+	GZip            *bool  `yaml:"gzip,omitempty" json:"gzip,omitempty"`
+}
+
+func (o *ImportOption) Validate() error {
+	if o == nil {
+		return errors.New("not defined")
+	}
+	if o.TemporaryBucket == "" {
+		return errors.New("temporary_bucket is not defined")
+	}
+	return nil
+}
+
+func (o *ImportOption) Clone() *ImportOption {
+	ret := &ImportOption{}
+	ret.MergeIn(o)
+	return ret
+}
+
+func (o *ImportOption) MergeIn(other *ImportOption) {
+	if other == nil {
+		return
+	}
+	if o.TemporaryBucket == "" {
+		o.TemporaryBucket = other.TemporaryBucket
+	}
+	if o.GZip == nil {
+		o.GZip = other.GZip
+	}
+
+}
+
+func (o *ImportOption) getCompression() bigquery.Compression {
+	if o.GZip == nil {
+		return bigquery.None
+	}
+	if *o.GZip {
+		return bigquery.Gzip
+	}
+	return bigquery.None
+}

--- a/processer.go
+++ b/processer.go
@@ -94,6 +94,7 @@ func (t *BigQueryTransporter) tmpObjectURL(record *ImportRequestRecord) string {
 func (t *BigQueryTransporter) load(ctx context.Context, record *ImportRequestRecord) error {
 	gcsRef := bigquery.NewGCSReference(t.tmpObjectURL(record))
 	gcsRef.AutoDetect = true
+	gcsRef.Compression = record.Option.getCompression()
 	gcsRef.MaxBadRecords = 100
 	logger.Debugf("prepre gcs reference: dump is %+v", gcsRef)
 

--- a/processer.go
+++ b/processer.go
@@ -95,7 +95,6 @@ func (t *BigQueryTransporter) load(ctx context.Context, record *ImportRequestRec
 	gcsRef := bigquery.NewGCSReference(t.tmpObjectURL(record))
 	gcsRef.AutoDetect = true
 	gcsRef.MaxBadRecords = 100
-	gcsRef.AllowJaggedRows = true
 	logger.Debugf("prepre gcs reference: dump is %+v", gcsRef)
 
 	bq, err := t.cloud.GetBigQueryClient(ctx, record.Target.ProjectID)

--- a/rule.go
+++ b/rule.go
@@ -37,10 +37,6 @@ type S3Soruce struct {
 	KeyRegexp string `yaml:"key_regexp"`
 }
 
-type ImportOption struct {
-	TemporaryBucket string `yaml:"temporary_bucket" json:"temporary_bucket"`
-}
-
 type S3Object struct {
 	Bucket string `json:"bucket"`
 	Object string `json:"object"`
@@ -66,11 +62,8 @@ func (r *Rule) Validate() error {
 	if r.BigQuery.Table == "" {
 		return errors.New("rule.bigquery.table is not defined")
 	}
-	if r.Option == nil {
-		return errors.New("rule.option is not defined")
-	}
-	if r.Option.TemporaryBucket == "" {
-		return errors.New("rule.option.temporary_bucket is not defined")
+	if err := r.Option.Validate(); err != nil {
+		return errors.Wrap(err, "rule.option")
 	}
 	return r.buildKeyMacher()
 }
@@ -240,20 +233,5 @@ func (bq *BigQueryDestination) MergeIn(other *BigQueryDestination) {
 	}
 	if bq.Table == "" {
 		bq.Table = other.Table
-	}
-}
-
-func (o *ImportOption) Clone() *ImportOption {
-	ret := &ImportOption{}
-	ret.MergeIn(o)
-	return ret
-}
-
-func (o *ImportOption) MergeIn(other *ImportOption) {
-	if other == nil {
-		return
-	}
-	if o.TemporaryBucket == "" {
-		o.TemporaryBucket = other.TemporaryBucket
 	}
 }

--- a/testdata/config/override.yaml
+++ b/testdata/config/override.yaml
@@ -10,6 +10,7 @@ big_query:
 
 option:
   temporary_bucket: bqin-import-tmp
+  gzip: true
 
 rules:
   - big_query:
@@ -17,6 +18,8 @@ rules:
       table: user
     s3:
       key_prefix: data/user
+    option:
+      gzip: false
   - big_query:
       dataset: test2
       table: $1_$2


### PR DESCRIPTION
Includes: 
  -  AllowJoggedRows is CSV only option. AutoDetect doesn't work well, decided not to support it.
  - When gzip compression not work bqin. support this.